### PR TITLE
Add pandas dependency and setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Evolution App
+
+This repository contains a Streamlit application.
+
+## Setup
+
+It is recommended to use a virtual environment. After activating it, install the Python dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+Then start the app with:
+
+```bash
+streamlit run app.py
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 streamlit
+pandas


### PR DESCRIPTION
## Summary
- add pandas to `requirements.txt`
- document setup steps using `pip install -r requirements.txt`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'streamlit')*
- `pip install -r requirements.txt` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_b_6866485e499c8326bc788e8ff4413081