### PR TITLE
Fix stray style variable

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,4 +1,3 @@
-STYLE = """
     <style>
         @import url('https://fonts.googleapis.com/css2?family=Segoe+UI&display=swap');
 


### PR DESCRIPTION
## Summary
- remove `STYLE =` prefix from `style.css`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'streamlit')*

------
https://chatgpt.com/codex/tasks/task_b_68665bb9f6f08326ac92d86e142c38fc