### PR TITLE
Update logo handling for light/dark themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,14 @@ Then start the app with:
 ```bash
 streamlit run app.py
 ```
+
+## Logos
+
+Create a folder named `images` in the repository root (already added) and add the
+two logo files there:
+
+- `PHC Evolution.svg` for the light theme
+- `PHC Evolution_white.svg` for the dark theme
+
+The application will automatically pick the correct image depending on the theme
+selected in Streamlit.

--- a/app.py
+++ b/app.py
@@ -1,8 +1,8 @@
 import streamlit as st
-from common import calculate_plan, format_euro, produtos, LOGO
+from common import calculate_plan, format_euro, produtos, setup_page
 
 st.set_page_config(layout="centered")
-st.markdown(LOGO, unsafe_allow_html=True)
+setup_page(dark=st.get_option("theme.base") == "dark")
 
 st.title("Simulador de Plano PHC Evolution")
 plano_atual = st.selectbox("Plano Atual", ["Corporate", "Advanced", "Enterprise"])

--- a/app_test.py
+++ b/app_test.py
@@ -4,10 +4,10 @@ import pandas as pd
 __test__ = False
 import unicodedata
 from io import StringIO
-from common import calculate_plan, format_euro, produtos, LOGO
+from common import calculate_plan, format_euro, produtos, setup_page
 
 st.set_page_config(layout="centered")
-st.markdown(LOGO, unsafe_allow_html=True)
+setup_page(dark=st.get_option("theme.base") == "dark")
 
 
 def normalize(text: str) -> str:

--- a/common.py
+++ b/common.py
@@ -8,9 +8,17 @@ with open("style.css", encoding="utf-8") as f:
 with open("style_dark.css", encoding="utf-8") as f:
     STYLE_DARK = f.read()
 
-LOGO = """
+IMAGES_DIR = "images"
+
+LOGO_LIGHT = f"""
     <div class="logo-container">
-        <img src="https://phcsoftware.com/pt/wp-content/uploads/sites/3/2023/11/logo.svg" width="220" />
+        <img src="{IMAGES_DIR}/PHC Evolution.svg" width="220" />
+    </div>
+"""
+
+LOGO_DARK = f"""
+    <div class="logo-container">
+        <img src="{IMAGES_DIR}/PHC Evolution_white.svg" width="220" />
     </div>
 """
 
@@ -72,8 +80,9 @@ produtos = {
 def setup_page(dark: bool = False) -> None:
     """Apply common Streamlit styling and logo."""
     style = STYLE_DARK if dark else STYLE_LIGHT
+    logo = LOGO_DARK if dark else LOGO_LIGHT
     st.markdown(style, unsafe_allow_html=True)
-    st.markdown(LOGO, unsafe_allow_html=True)
+    st.markdown(logo, unsafe_allow_html=True)
 
 
 def format_euro(valor: float) -> str:


### PR DESCRIPTION
## Summary
- prepare `images` directory for logo assets
- switch to `setup_page` helper in `app.py` and `app_test.py`
- use theme-aware logo selection in `common.py`
- document the new logo folder in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'streamlit')*

------
https://chatgpt.com/codex/tasks/task_b_6866842808c48326abddd286cbac710b