### PR TITLE
Fix euro symbol in UI

### DIFF
--- a/app_test.py
+++ b/app_test.py
@@ -37,13 +37,13 @@ def gerar_pdf(linhas: list[tuple[str, int, float, float]]) -> bytes:
     for prod, qtd, unit, total in linhas:
         pdf.cell(colw[0], 8, str(prod), border=1)
         pdf.cell(colw[1], 8, str(qtd), border=1, align="C")
-        pdf.cell(colw[2], 8, format_euro(unit), border=1, align="R")
-        pdf.cell(colw[3], 8, format_euro(total), border=1, align="R")
+        pdf.cell(colw[2], 8, format_euro(unit, pdf=True), border=1, align="R")
+        pdf.cell(colw[3], 8, format_euro(total, pdf=True), border=1, align="R")
         pdf.ln()
 
     valor_total = sum(t for _, _, _, t in linhas)
     pdf.cell(colw[0] + colw[1] + colw[2], 8, "Total", border=1)
-    pdf.cell(colw[3], 8, format_euro(valor_total), border=1, align="R")
+    pdf.cell(colw[3], 8, format_euro(valor_total, pdf=True), border=1, align="R")
 
     return pdf.output(dest="S").encode("latin-1")
 

--- a/common.py
+++ b/common.py
@@ -80,20 +80,18 @@ def setup_page(dark: bool = False) -> None:
     st.markdown(f'<div class="logo-container">{logo_svg}</div>', unsafe_allow_html=True)
 
 
-def format_euro(valor: float) -> str:
-    """Format a number as euro currency without using the Unicode euro sign.
+def format_euro(valor: float, *, pdf: bool = False) -> str:
+    """Return ``valor`` formatted in euros.
 
-    The ``fpdf`` library bundled with this project only supports Latin‑1
-    characters.  The standard Euro symbol (``\u20AC``) is not part of that
-    encoding and would therefore trigger ``UnicodeEncodeError`` when creating a
-    PDF.  To keep the Euro sign while staying compatible with Latin‑1 we use
-    the Windows‑1252 code point instead (``chr(128)``), which ``fpdf`` can
-    handle.
+    When ``pdf`` is ``True`` the Euro symbol is encoded using the
+    Windows‑1252 code point (``chr(128)``) so that the bundled ``fpdf``
+    library can render it correctly.  For normal UI display the standard
+    Unicode Euro sign is used.
     """
 
-    euro_cp1252 = chr(128)  # maps to the Euro sign under Windows‑1252
+    euro_symbol = chr(128) if pdf else "€"
     valor_str = f"{int(round(valor)):,}".replace(",", ".")
-    return f"{valor_str} {euro_cp1252}"
+    return f"{valor_str} {euro_symbol}"
 
 
 def calculate_plan(


### PR DESCRIPTION
## Summary
- fix euro symbol to use proper Unicode in the UI
- keep Windows-1252 symbol when generating PDFs
- update PDF generation to request CP1252 symbol

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'streamlit')*

------
https://chatgpt.com/codex/tasks/task_b_686690cebdb08326a04613f3922804db