### PR TITLE
Fix PDF euro encoding and cache font config

### DIFF
--- a/app_test.py
+++ b/app_test.py
@@ -13,8 +13,19 @@ if st is None or pd is None:
         return str(text)
 else:
     from common import calculate_plan, format_euro, produtos, setup_page
+    from pathlib import Path
+
     st.set_page_config(layout="centered")
     setup_page(dark=st.get_option("theme.base") == "dark")
+
+    _FONTS_DIR = Path("fonts_dir")
+    _FONT_REGULAR = _FONTS_DIR / "segoeui.ttf"
+    _FONT_BOLD = _FONTS_DIR / "segoeuib.ttf"
+    _FONT_NAME = "Helvetica"
+    _USE_CUSTOM_FONT = False
+    if _FONT_REGULAR.exists() and _FONT_REGULAR.stat().st_size > 100000:
+        _FONT_NAME = "SegoeUI"
+        _USE_CUSTOM_FONT = True
 
 
     def normalize(text: str) -> str:
@@ -27,22 +38,16 @@ else:
     def gerar_pdf(linhas: list[tuple[str, int, float, float]]) -> bytes:
         """Create a simple PDF with a table of products."""
         from fpdf import FPDF
-        from pathlib import Path
-    
+
         pdf = FPDF()
         pdf.add_page()
-    
-        fonts_dir = Path("fonts_dir")
-        font_regular = fonts_dir / "segoeui.ttf"
-        font_bold = fonts_dir / "segoeuib.ttf"
-        use_custom = False
-        font_name = "Helvetica"
-        if font_regular.exists() and font_regular.stat().st_size > 100000:
-            font_name = "SegoeUI"
-            pdf.add_font(font_name, "", str(font_regular), uni=True)
-            if font_bold.exists() and font_bold.stat().st_size > 100000:
-                pdf.add_font(font_name, "B", str(font_bold), uni=True)
-            use_custom = True
+
+        font_name = _FONT_NAME
+        use_custom = _USE_CUSTOM_FONT
+        if _USE_CUSTOM_FONT:
+            pdf.add_font(font_name, "", str(_FONT_REGULAR), uni=True)
+            if _FONT_BOLD.exists() and _FONT_BOLD.stat().st_size > 100000:
+                pdf.add_font(font_name, "B", str(_FONT_BOLD), uni=True)
     
         pdf.set_font(font_name, size=12)
         pdf.cell(0, 10, "Proposta interna Cegid PHC Evolution", ln=True, align="C")

--- a/common.py
+++ b/common.py
@@ -82,15 +82,16 @@ def setup_page(dark: bool = False) -> None:
 
 def format_euro(valor: float, *, pdf: bool = False) -> str:
     """Return ``valor`` formatted in euros.
-    
-    By default the function uses the Unicode Euro sign.  When
-    ``pdf`` is ``True`` the symbol is encoded as the Windows‑1252
-    code point (``chr(128)``) so that it can be rendered correctly
-    even when using the bundled ``fpdf`` standard fonts.
+
+    The formatting uses a dot as the thousands separator followed by a
+    trailing Euro symbol.  When ``pdf`` is ``True`` the Euro sign is returned
+    as the Windows‑1252 code point (``chr(128)``) so that ``fpdf`` can encode
+    it correctly when using the built‑in fonts.
     """
 
     valor_str = f"{int(round(valor)):,}".replace(",", ".")
-    return f"{valor_str} €"
+    symbol = chr(128) if pdf else "€"
+    return f"{valor_str} {symbol}"
 
 
 def calculate_plan(


### PR DESCRIPTION
## Summary
- fix `format_euro` to return the Windows‑1252 euro code when generating PDFs
- cache font configuration at module load time to avoid repeated file checks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6866a24391408326afd3ee78adcdc865