### PR TITLE
Add synonyms for DocumentosExtranet and Equipamento

### DIFF
--- a/app_test.py
+++ b/app_test.py
@@ -164,6 +164,7 @@ else:
             inventario_flag = False
             inv_subs = {
                 "equipamentos",
+                "equipamento",
                 "lotes",
                 "grelhas",
                 "localizações",
@@ -231,11 +232,14 @@ else:
                 "documentosintranet": "Documentos",
                 "doceletrointranet": "Documentos",
                 "doc eletro intranet": "Documentos",
+                "documentosextranet": "Documentos",
+                "documentos extranet": "Documentos",
                 "genai": "GenAI",
                 "formacao": "Formação",
                 "imoveis": "Imóveis",
                 "terminais portateis": "Inventário Avançado",
                 "terminais portáteis": "Inventário Avançado",
+                "equipamento": "Inventário Avançado",
                 "suporte extranet": "Suporte",
                 "suporteextranet": "Suporte",
                 "suporteintranet": "Suporte",


### PR DESCRIPTION
## Summary
- map unrecognized module names "DocumentosExtranet" and "Equipamento" to existing modules
- include `equipamento` as inventory submodule synonym

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686f8993672c8326a8a0eb932c8a58a7