### PR TITLE
Add per-user Web/Desktop selection

### DIFF
--- a/app.py
+++ b/app.py
@@ -16,10 +16,20 @@ if plano_atual == "Corporate":
         "Gestão Completo"
     ])
 
-utilizadores = st.number_input("Nº de Utilizadores de Gestão", min_value=0, step=1, format="%d")
+c1, c2 = st.columns(2)
+with c1:
+    utilizadores_desk = st.number_input(
+        "Nº Utilizadores Desktop de Gestão", min_value=0, step=1, format="%d"
+    )
+with c2:
+    utilizadores_web = st.number_input(
+        "Nº Utilizadores Web de Gestão", min_value=0, step=1, format="%d"
+    )
+utilizadores = utilizadores_desk + utilizadores_web
 
 # Captura das seleções
 selecoes = {}
+web_selecoes = {}
 for area, modulos in produtos.items():
     with st.expander(area, expanded=False):
         if area == "Projeto":
@@ -28,12 +38,25 @@ for area, modulos in produtos.items():
             if escolha != "Nenhum":
                 info = modulos[escolha]
                 if info.get("per_user"):
-                    selecoes[escolha] = st.number_input(
-                        f"Nº Utilizadores - {escolha}",
-                        min_value=1,
-                        step=1,
-                        format="%d",
-                    )
+                    cpd, cpw = st.columns(2)
+                    with cpd:
+                        qtd_desk = st.number_input(
+                            f"Nº Utilizadores Desktop - {escolha}",
+                            min_value=0,
+                            step=1,
+                            format="%d",
+                            key=f"{escolha}_desk",
+                        )
+                    with cpw:
+                        qtd_web = st.number_input(
+                            f"Nº Utilizadores Web - {escolha}",
+                            min_value=0,
+                            step=1,
+                            format="%d",
+                            key=f"{escolha}_web",
+                        )
+                    selecoes[escolha] = qtd_desk + qtd_web
+                    web_selecoes[escolha] = qtd_web
                 else:
                     selecoes[escolha] = 1
         else:
@@ -52,18 +75,33 @@ for area, modulos in produtos.items():
                         )
                 elif ativado:
                     if info.get("per_user"):
-                        selecoes[modulo] = st.number_input(
-                            f"Nº Utilizadores - {modulo}",
-                            min_value=1,
-                            step=1,
-                            format="%d",
-                        )
+                        cd, cw = st.columns(2)
+                        with cd:
+                            qtd_desk = st.number_input(
+                                f"Nº Utilizadores Desktop - {modulo}",
+                                min_value=0,
+                                step=1,
+                                format="%d",
+                                key=f"{modulo}_desk",
+                            )
+                        with cw:
+                            qtd_web = st.number_input(
+                                f"Nº Utilizadores Web - {modulo}",
+                                min_value=0,
+                                step=1,
+                                format="%d",
+                                key=f"{modulo}_web",
+                            )
+                        selecoes[modulo] = qtd_desk + qtd_web
+                        web_selecoes[modulo] = qtd_web
                     else:
                         selecoes[modulo] = 1
 
 # Lógica do plano
 if st.button("Calcular Plano Recomendado"):
-    resultado = calculate_plan(plano_atual, tipo_gestao, utilizadores, selecoes)
+    resultado = calculate_plan(
+        plano_atual, tipo_gestao, utilizadores, selecoes, web_selecoes
+    )
 
     for msg in resultado["warnings"]:
         st.warning(msg)

--- a/common.py
+++ b/common.py
@@ -26,39 +26,35 @@ def load_precos_produtos() -> pd.DataFrame:
     return pd.read_csv("precos_produtos.csv", sep=",")
 
 produtos = {
-    "Core e Transversais": {
+    "Funcionalidades Adicionais de Gestão": {
         "Inventário Avançado": {"plano": 3, "per_user": False},
-        "Ocupação": {"plano": 3, "per_user": False},
-        "Frota": {"plano": 3, "per_user": False},
         "Logística": {"plano": 5, "per_user": False},
+        "Frota": {"plano": 3, "per_user": False},
         "Denúncias": {"plano": 5, "per_user": False},
-        "Documentos": {"plano": 3, "per_user": False},
-        "GenAI": {"plano": 2, "per_user": False},
-        "CRM": {"plano": 3, "per_user": True},
         "BPM": {"plano": 5, "per_user": False},
-        "Ponto de Venda (POS/Restauração)": {"plano": 1, "per_user": True},
     },
-    "Área Financeira e Recursos Humanos": {
+    "Financeira": {
         "Contabilidade": {"plano": 3, "per_user": True},
         "Imobilizado": {"plano": 3, "per_user": True},
+    },
+    "Recursos Humanos": {
         "Vencimento": {"plano": 3, "per_user": True},
-        "SHST": {"plano": 3, "per_user": True},
         "Colaborador": {"plano": 5, "per_user": True},
         "Careers c/ Recrutamento": {"plano": 5, "per_user": True},
         "OKR": {"plano": 4, "per_user": True},
-        "Equipa": {"plano": 3, "per_user": True},
-        "Formação": {"plano": 3, "per_user": False},
-        "Imóveis": {"plano": 3, "per_user": False},
     },
-    "Outros": {
+    "Extras e Setoriais": {
+        "Ponto de Venda (POS/Restauração)": {"plano": 1, "per_user": True},
         "Suporte": {"plano": 2, "per_user": True},
+        "CRM": {"plano": 3, "per_user": True},
+        "Equipa": {"plano": 3, "per_user": True},
         "Ecommerce B2B": {"plano": 3, "per_user": False},
     },
     "Projeto": {
-        "Orçamentação": {"plano": 3, "per_user": True},
-        "Orçamentação + Medição": {"plano": 3, "per_user": True},
-        "Orçamentação + Medição + Controlo": {"plano": 3, "per_user": True},
-        "Full Project - Controlo + Medição + Orçamentação + Planeamento + Revisão de Preços": {
+        "Projeto | Orçamentação": {"plano": 3, "per_user": True},
+        "Projeto | Orçamentação + Medição": {"plano": 3, "per_user": True},
+        "Projeto | Orçamentação + Medição + Controlo": {"plano": 3, "per_user": True},
+        "Projeto | Full Project (Orçamentação + Medição + Controlo + Planeamento + Revisão de Preços)": {
             "plano": 3,
             "per_user": True,
         },


### PR DESCRIPTION
## Summary
- reorganize module categories in `common.produtos`
- allow specifying desktop and web users for the management plan and per-user modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6870c83984f48326a6d57b187d9ad103