### PR TITLE
Adjust Web/Desktop module options

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,18 @@
 import streamlit as st
 from common import calculate_plan, format_euro, produtos, setup_page
 
+WEB_MODULES = {
+    "CRM",
+    "Suporte",
+    "Equipa",
+    "Careers c/ Recrutamento",
+    "Vencimento",
+    "Contabilidade",
+    "Imobilizado",
+}
+
+WEB_ONLY_MODULES = {"Colaborador"}
+
 st.set_page_config(layout="centered")
 setup_page(dark=st.get_option("theme.base") == "dark")
 
@@ -38,16 +50,7 @@ for area, modulos in produtos.items():
             if escolha != "Nenhum":
                 info = modulos[escolha]
                 if info.get("per_user"):
-                    cpd, cpw = st.columns(2)
-                    with cpd:
-                        qtd_desk = st.number_input(
-                            f"Nº Utilizadores Desktop - {escolha}",
-                            min_value=0,
-                            step=1,
-                            format="%d",
-                            key=f"{escolha}_desk",
-                        )
-                    with cpw:
+                    if escolha in WEB_ONLY_MODULES:
                         qtd_web = st.number_input(
                             f"Nº Utilizadores Web - {escolha}",
                             min_value=0,
@@ -55,8 +58,36 @@ for area, modulos in produtos.items():
                             format="%d",
                             key=f"{escolha}_web",
                         )
-                    selecoes[escolha] = qtd_desk + qtd_web
-                    web_selecoes[escolha] = qtd_web
+                        selecoes[escolha] = qtd_web
+                        web_selecoes[escolha] = qtd_web
+                    elif escolha in WEB_MODULES:
+                        cpd, cpw = st.columns(2)
+                        with cpd:
+                            qtd_desk = st.number_input(
+                                f"Nº Utilizadores Desktop - {escolha}",
+                                min_value=0,
+                                step=1,
+                                format="%d",
+                                key=f"{escolha}_desk",
+                            )
+                        with cpw:
+                            qtd_web = st.number_input(
+                                f"Nº Utilizadores Web - {escolha}",
+                                min_value=0,
+                                step=1,
+                                format="%d",
+                                key=f"{escolha}_web",
+                            )
+                        selecoes[escolha] = qtd_desk + qtd_web
+                        web_selecoes[escolha] = qtd_web
+                    else:
+                        qtd_desk = st.number_input(
+                            f"Nº Utilizadores - {escolha}",
+                            min_value=0,
+                            step=1,
+                            format="%d",
+                        )
+                        selecoes[escolha] = qtd_desk
                 else:
                     selecoes[escolha] = 1
         else:
@@ -75,16 +106,7 @@ for area, modulos in produtos.items():
                         )
                 elif ativado:
                     if info.get("per_user"):
-                        cd, cw = st.columns(2)
-                        with cd:
-                            qtd_desk = st.number_input(
-                                f"Nº Utilizadores Desktop - {modulo}",
-                                min_value=0,
-                                step=1,
-                                format="%d",
-                                key=f"{modulo}_desk",
-                            )
-                        with cw:
+                        if modulo in WEB_ONLY_MODULES:
                             qtd_web = st.number_input(
                                 f"Nº Utilizadores Web - {modulo}",
                                 min_value=0,
@@ -92,8 +114,36 @@ for area, modulos in produtos.items():
                                 format="%d",
                                 key=f"{modulo}_web",
                             )
-                        selecoes[modulo] = qtd_desk + qtd_web
-                        web_selecoes[modulo] = qtd_web
+                            selecoes[modulo] = qtd_web
+                            web_selecoes[modulo] = qtd_web
+                        elif modulo in WEB_MODULES:
+                            cd, cw = st.columns(2)
+                            with cd:
+                                qtd_desk = st.number_input(
+                                    f"Nº Utilizadores Desktop - {modulo}",
+                                    min_value=0,
+                                    step=1,
+                                    format="%d",
+                                    key=f"{modulo}_desk",
+                                )
+                            with cw:
+                                qtd_web = st.number_input(
+                                    f"Nº Utilizadores Web - {modulo}",
+                                    min_value=0,
+                                    step=1,
+                                    format="%d",
+                                    key=f"{modulo}_web",
+                                )
+                            selecoes[modulo] = qtd_desk + qtd_web
+                            web_selecoes[modulo] = qtd_web
+                        else:
+                            qtd_desk = st.number_input(
+                                f"Nº Utilizadores - {modulo}",
+                                min_value=0,
+                                step=1,
+                                format="%d",
+                            )
+                            selecoes[modulo] = qtd_desk
                     else:
                         selecoes[modulo] = 1
 

--- a/app_test.py
+++ b/app_test.py
@@ -110,9 +110,12 @@ else:
         "CRM",
         "Suporte",
         "Equipa",
-        "Colaborador",
         "Careers c/ Recrutamento",
+        "Vencimento",
+        "Contabilidade",
+        "Imobilizado",
     }
+    WEB_ONLY_MODULES = {"Colaborador"}
     
     if texto_tabela:
         try:
@@ -418,7 +421,18 @@ else:
                 if escolha != "Nenhum":
                     info = modulos[escolha]
                     if info.get("per_user"):
-                        if escolha in WEB_MODULES:
+                        if escolha in WEB_ONLY_MODULES:
+                            def_web = web_data.get(escolha, 0)
+                            qtd_web = st.number_input(
+                                f"Nº Utilizadores Web - {escolha}",
+                                min_value=0,
+                                step=1,
+                                format="%d",
+                                value=def_web,
+                            )
+                            selecoes[escolha] = qtd_web
+                            web_data[escolha] = qtd_web
+                        elif escolha in WEB_MODULES:
                             def_total = import_data.get(escolha, 0)
                             def_web = web_data.get(escolha, 0)
                             def_desk = max(0, def_total - max(0, def_web - 1))
@@ -470,7 +484,19 @@ else:
                             )
                     elif ativado:
                         if info.get("per_user"):
-                            if modulo in WEB_MODULES:
+                            if modulo in WEB_ONLY_MODULES:
+                                def_web = web_data.get(modulo, 0)
+                                qtd_web = st.number_input(
+                                    f"Nº Utilizadores Web - {modulo}",
+                                    min_value=0,
+                                    step=1,
+                                    format="%d",
+                                    value=def_web,
+                                    key=f"{modulo}_web",
+                                )
+                                selecoes[modulo] = qtd_web
+                                web_data[modulo] = qtd_web
+                            elif modulo in WEB_MODULES:
                                 def_total = import_data.get(modulo, 0)
                                 def_web = web_data.get(modulo, 0)
                                 def_desk = max(0, def_total - max(0, def_web - 1))

--- a/common.py
+++ b/common.py
@@ -39,7 +39,7 @@ produtos = {
     },
     "Recursos Humanos": {
         "Vencimento": {"plano": 3, "per_user": True},
-        "Colaborador": {"plano": 5, "per_user": True},
+        "Colaborador": {"plano": 5, "per_user": True, "web_only": True},
         "Careers c/ Recrutamento": {"plano": 5, "per_user": True},
         "OKR": {"plano": 4, "per_user": True},
     },
@@ -227,9 +227,18 @@ def calculate_plan(
             base, unidade = preco_produtos.get((modulo, plano_final), (0, 0))
             custo_base = base
             if unidade and quantidade > 0:
-                web_total = web_selecoes.get(modulo, 0)
-                web_paid = max(0, min(web_total - 1, quantidade))
-                desk_paid = max(0, quantidade - web_paid)
+                info = None
+                for mods in produtos.values():
+                    if modulo in mods:
+                        info = mods[modulo]
+                        break
+                if info and info.get("web_only"):
+                    web_paid = quantidade
+                    desk_paid = 0
+                else:
+                    web_total = web_selecoes.get(modulo, 0)
+                    web_paid = max(0, min(web_total - 1, quantidade))
+                    desk_paid = max(0, quantidade - web_paid)
                 custo_extra_desk = desk_paid * unidade
                 custo_extra_web = web_paid * unidade
                 qtd_desk = desk_paid

--- a/tests/test_calculate_plan.py
+++ b/tests/test_calculate_plan.py
@@ -102,3 +102,21 @@ def test_web_module_allocation(common):
         9,
         3,
     )
+
+
+def test_web_only_module(common):
+    result = common.calculate_plan(
+        "Enterprise",
+        None,
+        5,
+        {"Colaborador": 5},
+        {"Colaborador": 5},
+    )
+    unit = float(read_module_row("Colaborador", 6)["preco_unidade"])
+    assert result["modulos_detalhe"]["Colaborador"] == (
+        0,
+        0,
+        unit * 5,
+        0,
+        5,
+    )


### PR DESCRIPTION
## Summary
- support modules that are Desktop only, Web only or both
- remove Desktop option from **Colaborador** module
- enable Web users for **Vencimento**, **Contabilidade** and **Imobilizado**
- update module cost calculation for web‑only modules
- test new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6870e227718483269c5b2566f5fb3383