### PR TITLE
Fix singular labels for additional users

### DIFF
--- a/app.py
+++ b/app.py
@@ -13,6 +13,32 @@ WEB_MODULES = {
 
 WEB_ONLY_MODULES = {"Colaborador"}
 
+
+def format_additional_users(qtd: int, tipo: str | None = None) -> str:
+    """Return a formatted string for ``qtd`` additional users.
+
+    ``tipo`` can be "Desktop" or "Web" to specify the user type."""
+    if tipo:
+        tipo = f" {tipo}"
+    else:
+        tipo = ""
+    if qtd == 1:
+        return f"1 Utilizador Adicional{tipo}"
+    return f"{qtd} Utilizadores Adicionais{tipo}"
+
+
+def format_full_users(qtd: int) -> str:
+    """Return a formatted string for ``qtd`` Full Users."""
+    return "1 Full User" if qtd == 1 else f"{qtd} Full Users"
+
+
+def format_postos(qtd: int, *, adicional: bool = False) -> str:
+    """Return a formatted string for ``qtd`` POS stations."""
+    label = "Posto" if qtd == 1 else "Postos"
+    if adicional:
+        label += " Adicional" if qtd == 1 else "s Adicionais"
+    return f"{qtd} {label}" if qtd != 1 else f"1 {label}"
+
 st.set_page_config(layout="centered")
 setup_page(dark=st.get_option("theme.base") == "dark")
 
@@ -81,8 +107,13 @@ for area, modulos in produtos.items():
                         selecoes[escolha] = qtd_desk + qtd_web
                         web_selecoes[escolha] = qtd_web
                     else:
+                        label = (
+                            f"Nº Postos - {escolha}"
+                            if escolha == "Ponto de Venda (POS/Restauração)"
+                            else f"Nº Utilizadores - {escolha}"
+                        )
                         qtd_desk = st.number_input(
-                            f"Nº Utilizadores - {escolha}",
+                            label,
                             min_value=0,
                             step=1,
                             format="%d",
@@ -137,8 +168,13 @@ for area, modulos in produtos.items():
                             selecoes[modulo] = qtd_desk + qtd_web
                             web_selecoes[modulo] = qtd_web
                         else:
+                            label = (
+                                f"Nº Postos - {modulo}"
+                                if modulo == "Ponto de Venda (POS/Restauração)"
+                                else f"Nº Utilizadores - {modulo}"
+                            )
                             qtd_desk = st.number_input(
-                                f"Nº Utilizadores - {modulo}",
+                                label,
                                 min_value=0,
                                 step=1,
                                 format="%d",
@@ -175,7 +211,7 @@ if st.button("Calcular Plano Recomendado"):
             if g1:
                 detalhes.append(
                     (
-                        f"Preço dos {g1} Full Users (6 a 10)",
+                        f"Preço de {format_full_users(g1)} (6 a 10)",
                         format_euro(g1 * p1),
                         True,
                     )
@@ -183,7 +219,7 @@ if st.button("Calcular Plano Recomendado"):
             if g2:
                 detalhes.append(
                     (
-                        f"Preço dos {g2} Full Users (11 a 50)",
+                        f"Preço de {format_full_users(g2)} (11 a 50)",
                         format_euro(g2 * p2),
                         True,
                     )
@@ -191,7 +227,7 @@ if st.button("Calcular Plano Recomendado"):
             if g3:
                 detalhes.append(
                     (
-                        f"Preço dos {g3} Full Users (>50)",
+                        f"Preço de {format_full_users(g3)} (>50)",
                         format_euro(g3 * p3),
                         True,
                     )
@@ -199,7 +235,7 @@ if st.button("Calcular Plano Recomendado"):
         else:
             detalhes.append(
                 (
-                    f"Preço dos {resultado['extras_utilizadores']} Full Users adicionais",
+                    f"Preço de {format_full_users(resultado['extras_utilizadores'])} adicional",
                     format_euro(resultado["custo_extra_utilizadores"]),
                     True,
                 )
@@ -209,9 +245,13 @@ if st.button("Calcular Plano Recomendado"):
         custo_base, custo_desk, custo_web, qtd_desk, qtd_web = custos
         detalhes.append((modulo, format_euro(custo_base), False))
         if custo_desk > 0:
+            if modulo == "Ponto de Venda (POS/Restauração)":
+                texto_extra = format_postos(qtd_desk, adicional=True)
+            else:
+                texto_extra = format_additional_users(qtd_desk, "Desktop")
             detalhes.append(
                 (
-                    f"{modulo} ({qtd_desk} Utilizadores Adicionais Desktop)",
+                    f"{modulo} ({texto_extra})",
                     format_euro(custo_desk),
                     True,
                 )
@@ -219,7 +259,7 @@ if st.button("Calcular Plano Recomendado"):
         if custo_web > 0:
             detalhes.append(
                 (
-                    f"{modulo} ({qtd_web} Utilizadores Adicionais Web)",
+                    f"{modulo} ({format_additional_users(qtd_web, 'Web')})",
                     format_euro(custo_web),
                     True,
                 )

--- a/app_test.py
+++ b/app_test.py
@@ -27,6 +27,25 @@ else:
         _FONT_NAME = "SegoeUI"
         _USE_CUSTOM_FONT = True
 
+    def format_additional_users(qtd: int, tipo: str | None = None) -> str:
+        if tipo:
+            tipo = f" {tipo}"
+        else:
+            tipo = ""
+        if qtd == 1:
+            return f"1 Utilizador Adicional{tipo}"
+        return f"{qtd} Utilizadores Adicionais{tipo}"
+
+
+    def format_full_users(qtd: int) -> str:
+        return "1 Full User" if qtd == 1 else f"{qtd} Full Users"
+
+    def format_postos(qtd: int, *, adicional: bool = False) -> str:
+        label = "Posto" if qtd == 1 else "Postos"
+        if adicional:
+            label += " Adicional" if qtd == 1 else "s Adicionais"
+        return f"{qtd} {label}" if qtd != 1 else f"1 {label}"
+
 
     def normalize(text: str) -> str:
         """Return lowercase text without accents."""
@@ -564,7 +583,7 @@ else:
                 if g1:
                     detalhes.append(
                         (
-                            f"Preço dos {g1} Full Users (6 a 10)",
+                            f"Preço de {format_full_users(g1)} (6 a 10)",
                             format_euro(g1 * p1),
                             True,
                         )
@@ -572,7 +591,7 @@ else:
                 if g2:
                     detalhes.append(
                         (
-                            f"Preço dos {g2} Full Users (11 a 50)",
+                            f"Preço de {format_full_users(g2)} (11 a 50)",
                             format_euro(g2 * p2),
                             True,
                         )
@@ -580,7 +599,7 @@ else:
                 if g3:
                     detalhes.append(
                         (
-                            f"Preço dos {g3} Full Users (>50)",
+                            f"Preço de {format_full_users(g3)} (>50)",
                             format_euro(g3 * p3),
                             True,
                         )
@@ -588,7 +607,7 @@ else:
             else:
                 detalhes.append(
                     (
-                        f"Preço dos {resultado['extras_utilizadores']} Full Users adicionais",
+                        f"Preço de {format_full_users(resultado['extras_utilizadores'])} adicional",
                         format_euro(resultado["custo_extra_utilizadores"]),
                         True,
                     )
@@ -598,9 +617,13 @@ else:
             custo_base, custo_desk, custo_web, qtd_desk, qtd_web = custos
             detalhes.append((modulo, format_euro(custo_base), False))
             if custo_desk > 0:
+                if modulo == "Ponto de Venda (POS/Restauração)":
+                    texto_extra = format_postos(qtd_desk, adicional=True)
+                else:
+                    texto_extra = format_additional_users(qtd_desk, 'Desktop')
                 detalhes.append(
                     (
-                        f"{modulo} ({qtd_desk} Utilizadores Adicionais Desktop)",
+                        f"{modulo} ({texto_extra})",
                         format_euro(custo_desk),
                         True,
                     )
@@ -608,7 +631,7 @@ else:
             if custo_web > 0:
                 detalhes.append(
                     (
-                        f"{modulo} ({qtd_web} Utilizadores Adicionais Web)",
+                        f"{modulo} ({format_additional_users(qtd_web, 'Web')})",
                         format_euro(custo_web),
                         True,
                     )
@@ -651,14 +674,14 @@ else:
                 g1, g2, g3 = resultado['extras_breakdown']
                 p1, p2, p3 = resultado['precos_extras']
                 if g1:
-                    linhas_pdf.append(("  Full Users (6 a 10)", g1, p1, g1 * p1))
+                    linhas_pdf.append((f"  {format_full_users(g1)} (6 a 10)", g1, p1, g1 * p1))
                 if g2:
-                    linhas_pdf.append(("  Full Users (11 a 50)", g2, p2, g2 * p2))
+                    linhas_pdf.append((f"  {format_full_users(g2)} (11 a 50)", g2, p2, g2 * p2))
                 if g3:
-                    linhas_pdf.append(("  Full Users (>50)", g3, p3, g3 * p3))
+                    linhas_pdf.append((f"  {format_full_users(g3)} (>50)", g3, p3, g3 * p3))
             else:
                 unit = resultado['custo_extra_utilizadores'] / resultado['extras_utilizadores']
-                linhas_pdf.append(("  Full Users adicionais", resultado['extras_utilizadores'], unit, resultado['custo_extra_utilizadores']))
+                linhas_pdf.append((f"  {format_full_users(resultado['extras_utilizadores'])} adicional", resultado['extras_utilizadores'], unit, resultado['custo_extra_utilizadores']))
     
         for modulo, custos in resultado['modulos_detalhe'].items():
             custo_base, custo_desk, custo_web, qtd_desk, qtd_web = custos
@@ -667,9 +690,13 @@ else:
 
             if custo_desk > 0:
                 unit_extra = custo_desk / qtd_desk if qtd_desk else custo_desk
+                if modulo == "Ponto de Venda (POS/Restauração)":
+                    texto_extra = format_postos(qtd_desk, adicional=True)
+                else:
+                    texto_extra = format_additional_users(qtd_desk, 'Desktop')
                 linhas_pdf.append(
                     (
-                        f"  {modulo} ({qtd_desk} Utilizadores Adicionais Desktop)",
+                        f"  {modulo} ({texto_extra})",
                         qtd_desk,
                         unit_extra,
                         custo_desk,
@@ -679,7 +706,7 @@ else:
                 unit_extra = custo_web / qtd_web if qtd_web else custo_web
                 linhas_pdf.append(
                     (
-                        f"  {modulo} ({qtd_web} Utilizadores Adicionais Web)",
+                        f"  {modulo} ({format_additional_users(qtd_web, 'Web')})",
                         qtd_web,
                         unit_extra,
                         custo_web,

--- a/common.py
+++ b/common.py
@@ -77,6 +77,16 @@ WEB_MODULES = {
 
 WEB_ONLY_MODULES = {"Colaborador"}
 
+# Maximum number of POS stations allowed per plan
+POS_LIMITS = {
+    1: 1,   # Essentials
+    2: 2,   # Standard
+    3: 5,   # Plus
+    4: 10,  # Advanced
+    5: 50,  # Premium
+    6: None,  # Ultimate has no limit
+}
+
 
 def setup_page(dark: bool = False) -> None:
     """Apply common Streamlit styling and logo."""
@@ -153,6 +163,15 @@ def calculate_plan(
         plano_utilizadores = max(pid for pid, _ in limites)
 
     planos.append(plano_utilizadores)
+
+    # Adjust plan based on number of POS stations
+    pos_qtd = selecoes.get("Ponto de Venda (POS/Restauração)", 0)
+    if pos_qtd:
+        for pid in sorted(POS_LIMITS):
+            limite = POS_LIMITS[pid]
+            if limite is None or pos_qtd <= limite:
+                planos.append(pid)
+                break
 
     for modulo in selecoes:
         for area in produtos.values():

--- a/tests/test_calculate_plan.py
+++ b/tests/test_calculate_plan.py
@@ -122,3 +122,15 @@ def test_web_only_module(common):
         0,
         4,
     )
+
+
+def test_pos_plan_limit(common):
+    result = common.calculate_plan(
+        "Corporate",
+        "Gestão Completo",
+        1,
+        0,
+        {"Ponto de Venda (POS/Restauração)": 6},
+    )
+    # 6 postos requerem o plano Advanced (10 postos)
+    assert result["plano_final"] == 4


### PR DESCRIPTION
## Summary
- add utilities to format user counts
- ensure singular form for 1 additional user on pricing breakdown and PDF
- add POS limit handling and new labels for POS stations
- add test for POS plan limits

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6870f358b874832694ee5ddd4ae8e407