### PR TITLE
Display Bank Connector pack costs

### DIFF
--- a/africa.py
+++ b/africa.py
@@ -1,7 +1,7 @@
 import streamlit as st
 from pathlib import Path
 from copy import deepcopy
-from common import calculate_plan, produtos, setup_page
+from common import BANK_PACK_PRICES, calculate_plan, produtos, setup_page
 
 WEB_MODULES = {
     "CRM",
@@ -389,6 +389,16 @@ if st.button("Calcular Plano Recomendado"):
             f"<p style='color:#000000;'>Necessário adicionar {packs} (total de {resultado['bancos_total']} bancos).</p>",
             unsafe_allow_html=True,
         )
+        if pack5:
+            st.markdown(
+                f"<p style='color:#000000;'>Bank Connector 5: {format_moeda(BANK_PACK_PRICES[5] * pack5)}</p>",
+                unsafe_allow_html=True,
+            )
+        if pack10:
+            st.markdown(
+                f"<p style='color:#000000;'>Bank Connector 10: {format_moeda(BANK_PACK_PRICES[10] * pack10)}</p>",
+                unsafe_allow_html=True,
+            )
 
     if "GenAI" in selecoes:
         st.markdown(

--- a/app.py
+++ b/app.py
@@ -1,5 +1,11 @@
 import streamlit as st
-from common import calculate_plan, format_euro, produtos, setup_page
+from common import (
+    BANK_PACK_PRICES,
+    calculate_plan,
+    format_euro,
+    produtos,
+    setup_page,
+)
 
 WEB_MODULES = {
     "CRM",
@@ -313,6 +319,16 @@ if st.button("Calcular Plano Recomendado"):
             f"<p style='color:#000000;'>Necessário adicionar {packs} (total de {resultado['bancos_total']} bancos).</p>",
             unsafe_allow_html=True,
         )
+        if pack5:
+            st.markdown(
+                f"<p style='color:#000000;'>Bank Connector 5: {format_euro(BANK_PACK_PRICES[5] * pack5)}</p>",
+                unsafe_allow_html=True,
+            )
+        if pack10:
+            st.markdown(
+                f"<p style='color:#000000;'>Bank Connector 10: {format_euro(BANK_PACK_PRICES[10] * pack10)}</p>",
+                unsafe_allow_html=True,
+            )
 
     if "GenAI" in selecoes:
         st.markdown(

--- a/app_test.py
+++ b/app_test.py
@@ -12,7 +12,13 @@ if st is None or pd is None:
     def normalize(text: str) -> str:
         return str(text)
 else:
-    from common import calculate_plan, format_euro, produtos, setup_page
+    from common import (
+        BANK_PACK_PRICES,
+        calculate_plan,
+        format_euro,
+        produtos,
+        setup_page,
+    )
     from pathlib import Path
 
     st.set_page_config(layout="centered")
@@ -685,6 +691,16 @@ else:
                 f"<p style='color:#000000;'>Necessário adicionar {packs} (total de {resultado['bancos_total']} bancos).</p>",
                 unsafe_allow_html=True,
             )
+            if pack5:
+                st.markdown(
+                    f"<p style='color:#000000;'>Bank Connector 5: {format_euro(BANK_PACK_PRICES[5] * pack5)}</p>",
+                    unsafe_allow_html=True,
+                )
+            if pack10:
+                st.markdown(
+                    f"<p style='color:#000000;'>Bank Connector 10: {format_euro(BANK_PACK_PRICES[10] * pack10)}</p>",
+                    unsafe_allow_html=True,
+                )
     
         if "genai" in extras_importados:
             st.markdown(

--- a/common.py
+++ b/common.py
@@ -87,6 +87,12 @@ POS_LIMITS = {
     6: None,  # Ultimate has no limit
 }
 
+# Prices for additional Bank Connector packs
+BANK_PACK_PRICES = {
+    5: 200,
+    10: 380,
+}
+
 
 def setup_page(dark: bool = False) -> None:
     """Apply common Streamlit styling and logo."""


### PR DESCRIPTION
## Summary
- expose new `BANK_PACK_PRICES` constant
- import price table in apps
- show price lines when additional bank packs are required

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68750589a1548326bd9c5377cb89661f