### PR TITLE
Remove company name field in Task Force app

### DIFF
--- a/task_force.py
+++ b/task_force.py
@@ -676,7 +676,6 @@ else:
                         else:
                             selecoes[modulo] = 1
     
-    cliente_final = st.text_input("Cliente Final")
 
     # Lógica do plano
     if st.button("Calcular Plano Recomendado"):
@@ -902,9 +901,8 @@ else:
         pdf_bytes = gerar_pdf(linhas_pdf)
         pdf_simples_bytes = gerar_pdf_sem_preco([(p, q) for p, q, _u, _t in linhas_pdf])
 
-        slug = normalize(cliente_final).replace(" ", "_") if cliente_final else ""
-        nome_orc = f"orcamento_{slug}.pdf" if slug else "orcamento.pdf"
-        nome_sim = f"simulacao_{slug}.pdf" if slug else "simulacao.pdf"
+        nome_orc = "orcamento.pdf"
+        nome_sim = "simulacao.pdf"
 
         col1, col2 = st.columns(2)
         with col1:


### PR DESCRIPTION
## Summary
- remove the `Cliente Final` text input in `task_force.py`
- use generic filenames for generated PDF downloads

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6877c3ba17448326b83224431c1fe711