### PR TITLE
docs: expand migration simulator rules

### DIFF
--- a/LOGICA_PLANOS.md
+++ b/LOGICA_PLANOS.md
@@ -47,12 +47,28 @@ Este documento resume as regras utilizadas pelas aplicações `app.py` (geral) e
 
 ## 3. Regras Extra da Aplicação de Migração
 
-`app_test.py` permite importar tabelas provenientes do PHC CS. Durante a leitura:
+`app_test.py` permite importar tabelas provenientes do PHC CS e aplica várias heurísticas antes de chamar `calculate_plan`:
 
-- Os nomes dos produtos são normalizados e convertidos para os correspondentes módulos do Evolution.
-- Módulos não disponíveis são ignorados e é apresentada uma informação ao utilizador.
-- Extras como `GenAI`, `Intrastat` ou `RGPD` adicionam-se ao conjunto `extras_importados`, influenciando o plano através de `extras_planos`.
-- O número de utilizadores pode ser inferido a partir da tabela importada.
+1. **Leitura e identificação do plano**
+   - O ficheiro aceita colunas separadas por ponto e vírgula ou tabulação contendo, pelo menos, `Produto` e `Quantidade`.
+   - Colunas opcionais `Plano` ou `Designação` são analisadas para deduzir o plano atual (Corporate, Advanced ou Enterprise).
+   - A linha "Gestão" define o número de utilizadores e tenta inferir o tipo de gestão (`Gestão Clientes`, `Gestão Terceiros` ou `Gestão Completo`).
+
+2. **Tratamento de quantidades**
+   - Campos `Rede`, `Mono` e `Web` calculam os utilizadores desktop e web. No plano Corporate cada licença de rede conta como dois utilizadores; nos restantes conta como um.
+   - Subprodutos como "equipamentos", "lotes", "localizações" ou "serviços" ativam automaticamente o módulo **Inventário Avançado**.
+   - A presença de "web" ou "intranet" em qualquer descrição força a inclusão do módulo **Documentos**.
+
+3. **Normalização de nomes**
+   - Os produtos são convertidos para minúsculas sem acentos e mapeados via um dicionário para os módulos oficiais.
+   - Partes antigas do módulo **Projeto** são combinadas para selecionar o equivalente mais completo disponível.
+
+4. **Extras e módulos especiais**
+   - Entradas que coincidam com `extras_planos` (`intrastat`, `rgpd`, `documentos`, `genai`, `sms`, `multilingua`, …) são adicionadas a `extras_importados`, podendo elevar o plano final.
+   - Módulos não suportados ou pertencentes a listas de exclusão são ignorados; módulos do antigo Manufactor apenas geram um aviso. Módulos desconhecidos são sinalizados ao utilizador.
+
+5. **Resultado**
+   - Após o processamento, são calculados os utilizadores de cada módulo (desktop e web) e as respetivas seleções, que são então passadas a `calculate_plan` para determinar o plano e custos finais.
 
 ## 4. Avisos e Dependências
 


### PR DESCRIPTION
## Summary
- document how migration app infers the plan and management type from imported tables
- explain quantity handling and automatic activation of Inventory and Documents modules
- describe normalization, extras mapping and treatment of unsupported modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68b0249db3088326ae3cb3ce5f0fdd41