### PR TITLE
Tratar POS e Restauração separadamente

### DIFF
--- a/africa.py
+++ b/africa.py
@@ -321,8 +321,9 @@ if st.button("Calcular Plano Recomendado"):
     for modulo, custos in resultado["modulos_detalhe"].items():
         custo_base, custo_desk, custo_web, qtd_desk, qtd_web = custos
         if modulo == "Ponto de Venda (POS/Restauração)" and pos_info:
-            ate_10, acima_10, preco_primeiro, preco_2_10, preco_maior_10 = pos_info
-            detalhes.append(("1º Ponto de Venda (POS/Restauração)", format_moeda(preco_primeiro), False))
+            num_primeiros, ate_10, acima_10, preco_primeiro, preco_2_10, preco_maior_10 = pos_info
+            for _ in range(num_primeiros):
+                detalhes.append(("1º Ponto de Venda (POS/Restauração)", format_moeda(preco_primeiro), False))
             if ate_10 > 0:
                 total = ate_10 * preco_2_10
                 detalhes.append(
@@ -427,8 +428,9 @@ if st.button("Calcular Plano Recomendado"):
         custo_base, custo_desk, custo_web, qtd_desk, qtd_web = custos
 
         if modulo == 'Ponto de Venda (POS/Restauração)' and pos_info:
-            ate_10, acima_10, preco_primeiro, preco_2_10, preco_maior_10 = pos_info
-            linhas_pdf.append(("1º Ponto de Venda (POS/Restauração)", 1, preco_primeiro, preco_primeiro))
+            num_primeiros, ate_10, acima_10, preco_primeiro, preco_2_10, preco_maior_10 = pos_info
+            for _ in range(num_primeiros):
+                linhas_pdf.append(("1º Ponto de Venda (POS/Restauração)", 1, preco_primeiro, preco_primeiro))
             if ate_10 > 0:
                 linhas_pdf.append((
                     f"  Ponto de Venda (POS/Restauração) - ({format_postos(ate_10, adicional=True)} - Escalão de 2 a 10)",

--- a/app.py
+++ b/app.py
@@ -251,8 +251,9 @@ if st.button("Calcular Plano Recomendado"):
     for modulo, custos in resultado["modulos_detalhe"].items():
         custo_base, custo_desk, custo_web, qtd_desk, qtd_web = custos
         if modulo == "Ponto de Venda (POS/Restauração)" and pos_info:
-            ate_10, acima_10, preco_primeiro, preco_2_10, preco_maior_10 = pos_info
-            detalhes.append(("1º Ponto de Venda (POS/Restauração)", format_euro(preco_primeiro), False))
+            num_primeiros, ate_10, acima_10, preco_primeiro, preco_2_10, preco_maior_10 = pos_info
+            for _ in range(num_primeiros):
+                detalhes.append(("1º Ponto de Venda (POS/Restauração)", format_euro(preco_primeiro), False))
             if ate_10 > 0:
                 total = ate_10 * preco_2_10
                 detalhes.append(

--- a/common.py
+++ b/common.py
@@ -133,6 +133,7 @@ def calculate_plan(
     web_selecoes: dict[str, int] | None = None,
     extras_importados: set[str] | None = None,
     extras_planos: dict[str, int] | None = None,
+    pos_counts: list[int] | None = None,
 ) -> dict:
     """Return planning information based on selections."""
     extras_importados = extras_importados or set()
@@ -272,13 +273,22 @@ def calculate_plan(
             preco_maior_10 = preco_produtos.get(("POS (>10)", plano_final), (0, 0))[1]
 
             if quantidade > 0:
-                restantes = quantidade - 1
-                ate_10 = min(restantes, 9)
-                acima_10 = max(restantes - 9, 0)
-                custo_base = preco_primeiro
+                grupos = pos_counts if pos_counts is not None else [quantidade]
+                extras_grupos = [max(q - 1, 0) for q in grupos]
+                num_primeiros = len(grupos)
+                ate_10 = sum(min(e, 9) for e in extras_grupos)
+                acima_10 = sum(max(e - 9, 0) for e in extras_grupos)
+                custo_base = num_primeiros * preco_primeiro
                 custo_extra = ate_10 * preco_2_10 + acima_10 * preco_maior_10
                 qtd_desk = ate_10 + acima_10
-                pos_breakdown = (ate_10, acima_10, preco_primeiro, preco_2_10, preco_maior_10)
+                pos_breakdown = (
+                    num_primeiros,
+                    ate_10,
+                    acima_10,
+                    preco_primeiro,
+                    preco_2_10,
+                    preco_maior_10,
+                )
             else:
                 custo_base = 0
                 custo_extra = 0

--- a/task_force.py
+++ b/task_force.py
@@ -189,6 +189,7 @@ else:
     
     import_data = {}
     web_data = {}
+    pos_counts = None
     utilizadores_importados = None
     utilizadores_desk_importados = None
     utilizadores_web_importados = 0
@@ -330,6 +331,14 @@ else:
                     "Web": [web_por_produto.get(p, 0) for p in tot_por_produto],
                 }
             )
+
+            aliases_pos = {"pos", "restauracao", "ponto de venda", "pontos de venda"}
+            pos_tmp = []
+            for _, row in df_import.iterrows():
+                if normalize(row["Produto"]) in aliases_pos:
+                    pos_tmp.append(int(row["Quantidade"]))
+            if pos_tmp:
+                pos_counts = pos_tmp
     
             if inventario_flag:
                 import_data["Inventário Avançado"] = 1
@@ -467,9 +476,9 @@ else:
                     continue
                 modulo_nome = nome_map.get(modulo_lower, modulo)
                 if modulo_nome in modulos_validos:
-                    import_data[modulo_nome] = quantidade
+                    import_data[modulo_nome] = import_data.get(modulo_nome, 0) + quantidade
                     if web_mod:
-                        web_data[modulo_nome] = web_mod
+                        web_data[modulo_nome] = web_data.get(modulo_nome, 0) + web_mod
                 elif modulo_lower in extras_planos:
                     extras_importados.add(modulo_lower)
                 else:
@@ -690,6 +699,7 @@ else:
             web_data,
             extras_importados,
             extras_planos,
+            pos_counts,
         )
     if st.session_state.get("resultado"):
         resultado = st.session_state["resultado"]
@@ -746,8 +756,9 @@ else:
         for modulo, custos in resultado["modulos_detalhe"].items():
             custo_base, custo_desk, custo_web, qtd_desk, qtd_web = custos
             if modulo == "Ponto de Venda (POS/Restauração)" and pos_info:
-                ate_10, acima_10, preco_primeiro, preco_2_10, preco_maior_10 = pos_info
-                detalhes.append(("1º Ponto de Venda (POS/Restauração)", format_euro(preco_primeiro), False))
+                num_primeiros, ate_10, acima_10, preco_primeiro, preco_2_10, preco_maior_10 = pos_info
+                for _ in range(num_primeiros):
+                    detalhes.append(("1º Ponto de Venda (POS/Restauração)", format_euro(preco_primeiro), False))
                 if ate_10 > 0:
                     total = ate_10 * preco_2_10
                     detalhes.append(
@@ -861,25 +872,26 @@ else:
         for modulo, custos in resultado['modulos_detalhe'].items():
             custo_base, custo_desk, custo_web, qtd_desk, qtd_web = custos
 
-            if modulo == 'Ponto de Venda (POS/Restauração)' and pos_info:
-                ate_10, acima_10, preco_primeiro, preco_2_10, preco_maior_10 = pos_info
+        if modulo == 'Ponto de Venda (POS/Restauração)' and pos_info:
+            num_primeiros, ate_10, acima_10, preco_primeiro, preco_2_10, preco_maior_10 = pos_info
+            for _ in range(num_primeiros):
                 linhas_pdf.append(("1º Ponto de Venda (POS/Restauração)", 1, preco_primeiro, preco_primeiro))
-                if ate_10 > 0:
-                    linhas_pdf.append((
-                        f"  Ponto de Venda (POS/Restauração) - ({format_postos(ate_10, adicional=True)} - Escalão de 2 a 10)",
-                        ate_10,
-                        preco_2_10,
-                        ate_10 * preco_2_10,
-                    ))
-                if acima_10 > 0:
-                    linhas_pdf.append((
-                        f"  Ponto de Venda (POS/Restauração) - ({format_postos(acima_10, adicional=True)} - Escalão de 11 a 50)",
-                        acima_10,
-                        preco_maior_10,
-                        acima_10 * preco_maior_10,
-                    ))
-            else:
-                linhas_pdf.append((modulo, 1, custo_base, custo_base))
+            if ate_10 > 0:
+                linhas_pdf.append((
+                    f"  Ponto de Venda (POS/Restauração) - ({format_postos(ate_10, adicional=True)} - Escalão de 2 a 10)",
+                    ate_10,
+                    preco_2_10,
+                    ate_10 * preco_2_10,
+                ))
+            if acima_10 > 0:
+                linhas_pdf.append((
+                    f"  Ponto de Venda (POS/Restauração) - ({format_postos(acima_10, adicional=True)} - Escalão de 11 a 50)",
+                    acima_10,
+                    preco_maior_10,
+                    acima_10 * preco_maior_10,
+                ))
+        else:
+            linhas_pdf.append((modulo, 1, custo_base, custo_base))
 
                 if custo_desk > 0:
                     unit_extra = custo_desk / qtd_desk if qtd_desk else custo_desk

--- a/task_force_teste.py
+++ b/task_force_teste.py
@@ -189,6 +189,7 @@ else:
     
     import_data = {}
     web_data = {}
+    pos_counts = None
     utilizadores_importados = None
     utilizadores_desk_importados = None
     utilizadores_web_importados = 0
@@ -330,6 +331,14 @@ else:
                     "Web": [web_por_produto.get(p, 0) for p in tot_por_produto],
                 }
             )
+
+            aliases_pos = {"pos", "restauracao", "ponto de venda", "pontos de venda"}
+            pos_tmp = []
+            for _, row in df_import.iterrows():
+                if normalize(row["Produto"]) in aliases_pos:
+                    pos_tmp.append(int(row["Quantidade"]))
+            if pos_tmp:
+                pos_counts = pos_tmp
     
             if inventario_flag:
                 import_data["Inventário Avançado"] = 1
@@ -467,9 +476,9 @@ else:
                     continue
                 modulo_nome = nome_map.get(modulo_lower, modulo)
                 if modulo_nome in modulos_validos:
-                    import_data[modulo_nome] = quantidade
+                    import_data[modulo_nome] = import_data.get(modulo_nome, 0) + quantidade
                     if web_mod:
-                        web_data[modulo_nome] = web_mod
+                        web_data[modulo_nome] = web_data.get(modulo_nome, 0) + web_mod
                 elif modulo_lower in extras_planos:
                     extras_importados.add(modulo_lower)
                 else:
@@ -688,6 +697,7 @@ else:
             web_data,
             extras_importados,
             extras_planos,
+            pos_counts,
         )
     
         for msg in resultado["warnings"]:
@@ -741,8 +751,9 @@ else:
         for modulo, custos in resultado["modulos_detalhe"].items():
             custo_base, custo_desk, custo_web, qtd_desk, qtd_web = custos
             if modulo == "Ponto de Venda (POS/Restauração)" and pos_info:
-                ate_10, acima_10, preco_primeiro, preco_2_10, preco_maior_10 = pos_info
-                detalhes.append(("1º Ponto de Venda (POS/Restauração)", format_euro(preco_primeiro), False))
+                num_primeiros, ate_10, acima_10, preco_primeiro, preco_2_10, preco_maior_10 = pos_info
+                for _ in range(num_primeiros):
+                    detalhes.append(("1º Ponto de Venda (POS/Restauração)", format_euro(preco_primeiro), False))
                 if ate_10 > 0:
                     total = ate_10 * preco_2_10
                     detalhes.append(
@@ -856,23 +867,24 @@ else:
         for modulo, custos in resultado['modulos_detalhe'].items():
             custo_base, custo_desk, custo_web, qtd_desk, qtd_web = custos
 
-            if modulo == 'Ponto de Venda (POS/Restauração)' and pos_info:
-                ate_10, acima_10, preco_primeiro, preco_2_10, preco_maior_10 = pos_info
+        if modulo == 'Ponto de Venda (POS/Restauração)' and pos_info:
+            num_primeiros, ate_10, acima_10, preco_primeiro, preco_2_10, preco_maior_10 = pos_info
+            for _ in range(num_primeiros):
                 linhas_pdf.append(("1º Ponto de Venda (POS/Restauração)", 1, preco_primeiro, preco_primeiro))
-                if ate_10 > 0:
-                    linhas_pdf.append((
-                        f"  Ponto de Venda (POS/Restauração) - ({format_postos(ate_10, adicional=True)} - Escalão de 2 a 10)",
-                        ate_10,
-                        preco_2_10,
-                        ate_10 * preco_2_10,
-                    ))
-                if acima_10 > 0:
-                    linhas_pdf.append((
-                        f"  Ponto de Venda (POS/Restauração) - ({format_postos(acima_10, adicional=True)} - Escalão de 11 a 50)",
-                        acima_10,
-                        preco_maior_10,
-                        acima_10 * preco_maior_10,
-                    ))
+            if ate_10 > 0:
+                linhas_pdf.append((
+                    f"  Ponto de Venda (POS/Restauração) - ({format_postos(ate_10, adicional=True)} - Escalão de 2 a 10)",
+                    ate_10,
+                    preco_2_10,
+                    ate_10 * preco_2_10,
+                ))
+            if acima_10 > 0:
+                linhas_pdf.append((
+                    f"  Ponto de Venda (POS/Restauração) - ({format_postos(acima_10, adicional=True)} - Escalão de 11 a 50)",
+                    acima_10,
+                    preco_maior_10,
+                    acima_10 * preco_maior_10,
+                ))
             else:
                 linhas_pdf.append((modulo, 1, custo_base, custo_base))
 

--- a/tests/test_calculate_plan.py
+++ b/tests/test_calculate_plan.py
@@ -144,3 +144,28 @@ def test_pos_plan_limit(common):
     )
     # 6 postos requerem o plano Advanced (10 postos)
     assert result["plano_final"] == 4
+
+
+def test_pos_restauracao_counts_separate(common):
+    result = common.calculate_plan(
+        "Enterprise",
+        None,
+        1,
+        0,
+        {"Ponto de Venda (POS/Restauração)": 4},
+        pos_counts=[1, 3],
+    )
+    preco_primeiro = float(read_module_row("POS (1º)", 6)["preco_base"])
+    preco_2_10 = float(read_module_row("POS (2 a 10)", 6)["preco_unidade"])
+    detalhes = result["modulos_detalhe"]["Ponto de Venda (POS/Restauração)"]
+    assert detalhes == (
+        preco_primeiro * 2,
+        preco_2_10 * 2,
+        0,
+        2,
+        0,
+    )
+    num_primeiros, ate_10, acima_10, *_ = result["pos_breakdown"]
+    assert num_primeiros == 2
+    assert ate_10 == 2
+    assert acima_10 == 0


### PR DESCRIPTION
## Summary
- Diferenciar vários módulos de POS/Restauração através do novo parâmetro `pos_counts` em `calculate_plan`
- Ajustar importação e detalhes nas aplicações para contar o 1º posto de cada módulo individualmente
- Adicionar teste que confirma a contagem separada de POS e Restauração

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b8161fccfc83268b6db7875ca14e8b