### PR TITLE
Allow running Streamlit apps directly with python

### DIFF
--- a/africa.py
+++ b/africa.py
@@ -1,4 +1,11 @@
 import streamlit as st
+
+if __name__ == "__main__" and not st.runtime.exists():  # pragma: no cover - CLI guard
+    import sys
+    import streamlit.web.cli as stcli
+
+    sys.argv = ["streamlit", "run", __file__] + sys.argv[1:]
+    sys.exit(stcli.main())
 from pathlib import Path
 from copy import deepcopy
 from common import BANK_PACK_PRICES, calculate_plan, produtos, setup_page

--- a/app.py
+++ b/app.py
@@ -1,4 +1,11 @@
 import streamlit as st
+
+if __name__ == "__main__" and not st.runtime.exists():  # pragma: no cover - CLI guard
+    import sys
+    import streamlit.web.cli as stcli
+
+    sys.argv = ["streamlit", "run", __file__] + sys.argv[1:]
+    sys.exit(stcli.main())
 from common import (
     BANK_PACK_PRICES,
     calculate_plan,

--- a/app_test.py
+++ b/app_test.py
@@ -1,6 +1,12 @@
 try:
     import streamlit as st
     import pandas as pd
+    if __name__ == "__main__" and not st.runtime.exists():  # pragma: no cover - CLI guard
+        import sys
+        import streamlit.web.cli as stcli
+
+        sys.argv = ["streamlit", "run", __file__] + sys.argv[1:]
+        sys.exit(stcli.main())
 except ModuleNotFoundError:  # pragma: no cover - optional dependency
     st = None
     pd = None

--- a/task_force.py
+++ b/task_force.py
@@ -1,6 +1,12 @@
 try:
     import streamlit as st
     import pandas as pd
+    if __name__ == "__main__" and not st.runtime.exists():  # pragma: no cover - CLI guard
+        import sys
+        import streamlit.web.cli as stcli
+
+        sys.argv = ["streamlit", "run", __file__] + sys.argv[1:]
+        sys.exit(stcli.main())
 except ModuleNotFoundError:  # pragma: no cover - optional dependency
     st = None
     pd = None

--- a/task_force_teste.py
+++ b/task_force_teste.py
@@ -1,6 +1,12 @@
 try:
     import streamlit as st
     import pandas as pd
+    if __name__ == "__main__" and not st.runtime.exists():  # pragma: no cover - CLI guard
+        import sys
+        import streamlit.web.cli as stcli
+
+        sys.argv = ["streamlit", "run", __file__] + sys.argv[1:]
+        sys.exit(stcli.main())
 except ModuleNotFoundError:  # pragma: no cover - optional dependency
     st = None
     pd = None


### PR DESCRIPTION
## Summary
- guard Streamlit apps to auto-launch Streamlit when run with `python`
- applies to africa.py, app.py, app_test.py, task_force.py, and task_force_teste.py

## Testing
- `pytest -q`
- `python task_force_teste.py`


------
https://chatgpt.com/codex/tasks/task_b_68b822d755508326a4f529506f0b96f1